### PR TITLE
Support legacy rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
-{pre_hooks,
-  [{"(linux|darwin|solaris|freebsd)", compile, "./build.sh"}]}.
-{post_hooks,
-  [{"(linux|darwin|solaris|freebsd)", clean, "rm -f priv/granderl.so"}]}.
+{pre_hooks, [{compile, "./build.sh"}]}.
+{post_hooks, [{clean, "rm -f priv/granderl.so"}]}.
+%% For rebar2 compatibility: everything is built by build.sh, so we
+%% needn't specify any dependencies here.
+{port_specs, [{"priv/granderl.so", []}]}.
 
 {profiles,
   [{test,


### PR DESCRIPTION
This is a bit of a hack -- by setting port_specs empty, we ensure that
rebar2's port compiler won't try to do anything after we've already
build the SO in build.sh.

Closes #3.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenrove/granderl/4)

<!-- Reviewable:end -->
