### PR TITLE
List files essential for hex.pm packaging

### DIFF
--- a/src/granderl.app.src
+++ b/src/granderl.app.src
@@ -5,6 +5,7 @@
   {maintainers, ["Julian Squires"]},
   {licenses, ["Apache"]},
   {links, [{"GitHub", "https://github.com/tokenrove/granderl"}]},
+  {files, ["build.sh", "preamble.sh", "c_src/"]},
   {applications, [
     kernel,
     stdlib


### PR DESCRIPTION
This should fix the current hex.pm packaging issue, hopefully.  (Would be nice if I had a better way to test other than publish and pray...)