### PR TITLE
Use gnu99 rather than gnu11

### DIFF
--- a/preamble.sh
+++ b/preamble.sh
@@ -2,7 +2,7 @@ set -eu
 
 ERTS_INCLUDE_DIR=${ERTS_INCLUDE_DIR:-$(erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")}
 CC=${CC:-cc}
-CFLAGS="-fPIC -I${ERTS_INCLUDE_DIR} -std=gnu11 \
+CFLAGS="-fPIC -I${ERTS_INCLUDE_DIR} -std=gnu99 \
   -Wall -Wextra -Wno-missing-field-initializers \
   -O3 ${CFLAGS:--march=native -mtune=native -ggdb}"
 LDFLAGS=${LDFLAGS:-}


### PR DESCRIPTION
The latter was optimistic in terms of features actually used in the
code, and we can support some older compilers by using the former
instead.

Closes #10.