### PR TITLE
Implement "rdtsc" for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 os:
   - linux
+arch:
+  - amd64
+  - arm64
 language: erlang
 env:
   - CC=gcc-6 IMPLEMENTATION=rdrand
@@ -16,10 +19,6 @@ script:
   - ./dieharder.sh
 dist: trusty
 group: edge
-notifications:
-  email: false
-  slack:
-    secure: CGZRqldOQ4CFBkWnG7E+D5RpQdYpt2fT9MQGDJV7terCF1aWnJanIMMl4UZtWTZY1cMyANpC07pPePrd+ql8mgis+0AUyomKseUlpIQffYKYZVRT+/frHGTjF+Fhqleq3gKR96lbQGrij8cuHUt2nDu5+bNl0QLmIllwfbagxIRzQUCtnPCdGQ6Fgi8+mY2sH3FgCEnq+czbWpWHlMqBzFq+Zkl8bvOWzMjifOq+KGXNMzRjOzd43vqXdEKY0PAz3TV8WP47HHbfsK9T8+w4HDBV7514AqXE970lHngsSk2c/S1C+Dr0V4P6GCwNaTK5eRCzkv8AT17LbS2/Ys2mS0T3daAKG4upllIkcKVlhkJ2SEYuqxNFoRj0TV770cEnbHRp/OgN/2ltgXHECnfSXHiHnrE5DgjSMUsrGAnVZ1sl3H2yt54tbsbSJwwz1Te2dbCK0613rZMCu/5xyBm6co1U2QJxVXBYKswyTcyGTbAlWREuAutZ5oc+tABlIIAbLQplb8Mp23bz1Ig71FAPPRkNDaDm/yv4nRT7MclYDT7PJ0dCz2MkoNALLJylujPfDCWopLwKnRremdRyCppJ3s7jg09j9MD0dlK+lui0B0cvWmFEbU2jpGDQ7yuX8tHS3Md5FG5+f38URyGM11P74amPyrYcacXGjZ8qFToVb8s=
 addons:
   apt:
     sources:

--- a/c_src/rdtsc.h
+++ b/c_src/rdtsc.h
@@ -7,6 +7,13 @@ inline void rdtsc(uint64_t *t, uint64_t *u)
 {
     asm volatile ("rdtsc" : "=a" (*t), "=d" (*u));
 }
+#elif defined(__aarch64__) && defined(__APPLE__)
+#include <mach/mach_time.h>
+
+inline void rdtsc(uint64_t *t, uint64_t *u __attribute__((unused)))
+{
+    *t = mach_absolute_time();
+}
 #else
 #error "Read your platform's perf counter here"
 #endif


### PR DESCRIPTION
We don't fill u, but then again, that's reasonably within the spirit of this library.  ~~This is under the assumption that PMCCNTR_EL0 will be readable from userspace, which seems to be a fair assumption at least from some light testing.  There are also reports that this counter might read zero under some circumstances; more testing is required to verify if this is an actual issue.~~ Revised to call `mach_absolute_time` at least for macOS which should satisfy basic uses.  Punting on an implementation for aarch64 otherwise.

Fixes #13.