### PR TITLE
Fix include dir for OTP-26

### DIFF
--- a/preamble.sh
+++ b/preamble.sh
@@ -1,6 +1,6 @@
 set -eu
 
-ERTS_INCLUDE_DIR=${ERTS_INCLUDE_DIR:-$(erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")}
+ERTS_INCLUDE_DIR=${ERTS_INCLUDE_DIR:-$(erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop)}
 CC=${CC:-cc}
 CFLAGS="-fPIC -I${ERTS_INCLUDE_DIR} -std=gnu11 \
   -Wall -Wextra -Wno-missing-field-initializers \


### PR DESCRIPTION
On `OTP-26-rc3` the include dir resolution fails:

```
lpgauth@Louis-Philippes-MacBook-Pro shackle % erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])."
Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).
```

This used to work because of a race condition which was fixed. Stop needs to be called last.

```
lpgauth@Louis-Philippes-MacBook-Pro shackle % erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop
/Users/lpgauth/Erlang/26.0-rc3/erts-14.0/include/%
```