### PR TITLE
Add native ARM64 support for rdtsc

### DIFF
--- a/c_src/rdtsc.h
+++ b/c_src/rdtsc.h
@@ -7,12 +7,12 @@ inline void rdtsc(uint64_t *t, uint64_t *u)
 {
     asm volatile ("rdtsc" : "=a" (*t), "=d" (*u));
 }
-#elif defined(__aarch64__) && defined(__APPLE__)
-#include <mach/mach_time.h>
-
+#elif defined(__aarch64__)
+// Userspace equivalent of rdtsc readable in user-space:
+// https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/CNTVCT-EL0--Counter-timer-Virtual-Count-register
 inline void rdtsc(uint64_t *t, uint64_t *u __attribute__((unused)))
 {
-    *t = mach_absolute_time();
+    asm volatile("mrs %0, cntvct_el0" : "=r" (*t));
 }
 #else
 #error "Read your platform's perf counter here"


### PR DESCRIPTION
Ran into an issue where while building on docker on a Mac, the rdtsc function would not compile due there not being a non-apple implementation for aarch64.

Did a bit of digging and the `cntvct_el0` register seems to be more or less equivalent to rdtsc while also working in user space. Code has been blatantly copied from the Linux kernel (link provided).  Note that we could probably remove the `__APPLE__` branch if this happens to work well as it would be redundant.

Relevant documentation: https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/CNTVCT-EL0--Counter-timer-Virtual-Count-register